### PR TITLE
2023083100 release code

### DIFF
--- a/version.php
+++ b/version.php
@@ -27,13 +27,13 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version   = 2023031400;
+$plugin->version = 2023083100;
 
 // Requires this Moodle version - 2.7.
-$plugin->requires   = 2017110800;
+$plugin->requires = 2017110800;
 
 // Full name of the plugin (used for diagnostics).
-$plugin->component  = 'atto_panoptoltibutton';
+$plugin->component = 'atto_panoptoltibutton';
 
 // Dependencies.
 $plugin->dependencies = array(

--- a/view.php
+++ b/view.php
@@ -23,97 +23,93 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-function init_panoptoltibutton_view() {
-    global $DB, $CFG, $COURSE;
-    if (empty($CFG)) {
-        require_once(dirname(__FILE__) . '/../../../../../config.php');
+global $DB, $CFG, $COURSE;
+if (empty($CFG)) {
+    require_once(dirname(__FILE__) . '/../../../../../config.php');
+}
+require_once($CFG->dirroot . '/blocks/panopto/lib/block_panopto_lib.php');
+require_once($CFG->libdir  . '/accesslib.php'); // Access control functions
+require_once($CFG->dirroot . '/mod/lti/lib.php');
+require_once($CFG->dirroot . '/mod/lti/locallib.php');
+require_once($CFG->dirroot . '/blocks/panopto/lib/lti/panoptoblock_lti_utility.php');
+
+$configuredserverarray = panopto_get_configured_panopto_servers();
+
+$contenturl = optional_param('contenturl', '', PARAM_URL);
+
+$contentverified = false;
+
+if ($contenturl) {
+    foreach($configuredserverarray as  $possibleserver) {
+        $contenthost = parse_url($contenturl, PHP_URL_HOST);
+
+        if (stripos($contenthost, $possibleserver) !== false) {
+            $contentverified = true;
+            break;
+        }
     }
-    require_once($CFG->dirroot . '/blocks/panopto/lib/block_panopto_lib.php');
-    require_once($CFG->libdir .'/accesslib.php'); // Access control functions
-    require_once($CFG->dirroot . '/mod/lti/lib.php');
-    require_once($CFG->dirroot . '/mod/lti/locallib.php');
-    require_once($CFG->dirroot . '/blocks/panopto/lib/lti/panoptoblock_lti_utility.php');
-
-    $configuredserverarray = panopto_get_configured_panopto_servers();
-
-    $contenturl = optional_param('contenturl', '', PARAM_URL);
-
-    $contentverified = false;
-
-    if ($contenturl) {
-        foreach($configuredserverarray as  $possibleserver) {
-            $contenthost = parse_url($contenturl, PHP_URL_HOST);
-
-            if (stripos($contenthost, $possibleserver) !== false) {
-                $contentverified = true;
-                break;
-            }
-        }
-    } else {
-        $contentverified = true;
-    }
-
-    if ($contentverified) {
-        $resourcelinkid = required_param('resourcelinkid', PARAM_ALPHANUMEXT);
-        $ltitypeid = required_param('ltitypeid', PARAM_INT);
-        $customdata = optional_param('custom', '', PARAM_RAW_TRIMMED);
-
-        require_login();
-
-        // Make sure $ltitypeid is valid.
-        $ltitype = $DB->get_record('lti_types', ['id' => $ltitypeid], '*', MUST_EXIST);
-
-        $lti = new stdClass();
-
-        // Try to detect if we are viewing content from an iframe nested in course, get the Id param if it exists.
-        $courseid = 0;
-        if (!empty($_SERVER['HTTP_REFERER']) && (strpos($_SERVER['HTTP_REFERER'], "/course/view.php") !== false)) {
-            $components = parse_url($_SERVER['HTTP_REFERER']);
-            parse_str($components['query'], $results);
-
-            if (!empty($results['id'])) {
-                $lti->course = $results['id'];
-                $course = $DB->get_record('course', array('id' => $results['id']), '*', MUST_EXIST);
-                $courseid = $course->id;
-                $context = context_course::instance($results['id']);
-                $PAGE->set_context($context);
-                require_login($course, true);
-            }
-        }
-
-        $lti->id = $resourcelinkid;
-        $lti->typeid = $ltitypeid;
-        $lti->launchcontainer = LTI_LAUNCH_CONTAINER_WINDOW;
-        $lti->toolurl = $contenturl;
-        $lti->custom = new stdClass();
-        $lti->instructorcustomparameters = [];
-        $lti->debuglaunch = false;
-        if ($customdata) {
-            $decoded = json_decode($customdata, true);
-
-            foreach ($decoded as $key => $value) {
-                $lti->custom->$key = $value;
-            }
-        }
-
-        // LTI 1.3 login request.
-        $config = lti_get_type_type_config($ltitypeid);
-        if ($config->lti_ltiversion === LTI_VERSION_1P3) {
-            if (!isset($SESSION->lti_initiatelogin_status)) {
-                echo lti_initiate_login($courseid,
-                    "atto_panoptoltibutton,'',{$ltitypeid},{$resourcelinkid},{$contenturl},{$customdata}",
-                    $lti,
-                    $config
-                );
-                exit;
-            }
-        }
-
-        echo \panoptoblock_lti_utility::launch_tool($lti);
-    } else {
-        echo get_string('invalid_content_host', 'atto_panoptoltibutton');
-    }
+} else {
+    $contentverified = true;
 }
 
-init_panoptoltibutton_view();
+if ($contentverified) {
+    $resourcelinkid = required_param('resourcelinkid', PARAM_ALPHANUMEXT);
+    $ltitypeid = required_param('ltitypeid', PARAM_INT);
+    $customdata = optional_param('custom', '', PARAM_RAW_TRIMMED);
+
+    require_login();
+
+    // Make sure $ltitypeid is valid.
+    $ltitype = $DB->get_record('lti_types', ['id' => $ltitypeid], '*', MUST_EXIST);
+
+    $lti = new stdClass();
+
+    // Try to detect if we are viewing content from an iframe nested in course, get the Id param if it exists.
+    $courseid = 0;
+    if (!empty($_SERVER['HTTP_REFERER']) && (strpos($_SERVER['HTTP_REFERER'], "/course/view.php") !== false)) {
+        $components = parse_url($_SERVER['HTTP_REFERER']);
+        parse_str($components['query'], $results);
+
+        if (!empty($results['id'])) {
+            $lti->course = $results['id'];
+            $course = $DB->get_record('course', array('id' => $results['id']), '*', MUST_EXIST);
+            $courseid = $course->id;
+            $context = context_course::instance($results['id']);
+            $PAGE->set_context($context);
+            require_login($course, true);
+        }
+    }
+
+    $lti->id = $resourcelinkid;
+    $lti->typeid = $ltitypeid;
+    $lti->launchcontainer = LTI_LAUNCH_CONTAINER_WINDOW;
+    $lti->toolurl = $contenturl;
+    $lti->custom = new stdClass();
+    $lti->instructorcustomparameters = [];
+    $lti->debuglaunch = false;
+    if ($customdata) {
+        $decoded = json_decode($customdata, true);
+
+        foreach ($decoded as $key => $value) {
+            $lti->custom->$key = $value;
+        }
+    }
+
+    // LTI 1.3 login request.
+    $config = lti_get_type_type_config($ltitypeid);
+    if ($config->lti_ltiversion === LTI_VERSION_1P3) {
+        if (!isset($SESSION->lti_initiatelogin_status)) {
+            echo lti_initiate_login($courseid,
+                "atto_panoptoltibutton,'',{$ltitypeid},{$resourcelinkid},{$contenturl},{$customdata}",
+                $lti,
+                $config
+            );
+            exit;
+        }
+    }
+
+    echo \panoptoblock_lti_utility::launch_tool($lti);
+} else {
+    echo get_string('invalid_content_host', 'atto_panoptoltibutton');
+}
 


### PR DESCRIPTION
This is the current stable release version of the Panopto LTI Button for Atto Plugin.

This version supports (a) Moodle 3.9, 3.11, 4.0, 4.1, 4.2 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Updating the Panopto LTI Button for Atto plugin to this version also required that you update the Panopto Moodle Block plugin to version 2022122000 or higher.

Below is the list of updates from the previous stable release (2023031400).
- Added support for Moodle 4.2
- Fixed an issue where the Panopto LTI Button for Atto may show hidden LTI tools in the dropdown.
- Fixed an issue that could cause slow performance when loading the LTI tools in the Panopto LTI Button for Atto if the Moodle site contained a large number of LTI tools.
