### PR TITLE
2024070900 release code

### DIFF
--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version = 2024012500;
+$plugin->version = 2024070900;
 
 // Requires this Moodle version - 3.9.0.
 $plugin->requires = 2020061500;


### PR DESCRIPTION
This is the current release version of the Panopto LTI Button for Atto Plugin.

This version supports (a) Moodle 4.1, 4.2, 4.3, 4.4 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Updating the Panopto LTI Button for Atto plugin to this version also required that you update the Panopto Moodle Block plugin to version 2022122000 or higher.

Below is the list of updates from the previous stable release (2024012500).

- Added support for Moodle 4.4
